### PR TITLE
compatibility with python<3.6

### DIFF
--- a/django_json_ld/templatetags/json_ld.py
+++ b/django_json_ld/templatetags/json_ld.py
@@ -9,5 +9,5 @@ register = template.Library()
 @register.simple_tag
 def render_json_ld(structured_data):
     dumped = json.dumps(structured_data, ensure_ascii=False)
-    text = f"<script type=application/ld+json>{dumped}</script>"
+    text = "<script type=application/ld+json>{dumped}</script>".format(dumped=dumped)
     return mark_safe(text)


### PR DESCRIPTION
Hi @hiimdoublej,

This PR makes `django-json-ld` compatible with python versions older than 3.6.

Let me know if you want me to make any adjustments.

Regards