### PR TITLE
Add CBV mixins and Detail view

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,20 @@ INSTALLED_APPS = [
 ]
 ```
 
+## Settings
+You can override the following options in settings.py:
+
+`JSON_LD_CONTEXT_ATTRIBUTE`: the context attribute name used in `django_json_ld`'s Class-Based Views (CBV). Defaults to `'sd'`.
+
+`JSON_LD_MODEL_ATTRIBUTE`: the model attribute name used by `JsonLdDetailView` to get the model's structured data. Defaults to `'sd'`.
+
+`JSON_LD_DEFAULT_CONTEXT`: default json-ld context when using `django_json_ld`'s CBVs. Defaults to `'https://schema.org'`.
+
+`JSON_LD_DEFAULT_TYPE`: default json-ld type when using `django_json_ld`'s CBVs. Defaults to `'Thing'`.
+
+`JSON_LD_GENERATE_URL`: generate json-ld's `url` field when using `django_json_ld`'s CBVs. Defaults to `True`.
+
+
 ## Usage Example
 Assuming you have a structured data `sd` like the following in your context (copied from the link above).
 ```
@@ -52,3 +66,42 @@ Would render into:
 }
 </script>
 ```
+
+### Class-Based View example
+
+views.py
+```python
+from django_json_ld.views import JsonLdDetailView
+
+class ProductDetailView(JsonLdDetailView):
+    model=Product
+```
+
+models.py
+```python
+class Product(models.Model):
+    name = models.CharField(_('Name'), max_length=255)
+    description = models.TextField(_('Description'))
+    
+    @property
+    def sd(self):
+        return {
+            "@type": 'Product',
+            "description": self.description,
+            "name": self.name,
+        }
+```
+
+By using  `{% render_json_ld sd %}`, as explained in the previous example, would render into something like:
+
+```json
+{
+    "@context":"https://schema.org",    
+    "@type":"Product",
+    "name":"The Product",
+    "description":"A great product.",
+    "url":"http://example.org/products/1/the-product/"
+}
+```
+
+In the above example `JsonLdDetailView` adds `sd` to `ProductDetailView`'s context, using `Product`'s own `sd` property. The `url` is generated automatically by `JsonLdDetailView`. This behaviour is configurable through settings.

--- a/django_json_ld/settings.py
+++ b/django_json_ld/settings.py
@@ -1,0 +1,9 @@
+from django.conf import settings
+
+
+CONTEXT_ATTRIBUTE = getattr(settings, 'JSON_LD_CONTEXT_ATTRIBUTE', 'sd')
+MODEL_ATTRIBUTE = getattr(settings,   'JSON_LD_MODEL_ATTRIBUTE', 'sd')
+
+DEFAULT_CONTEXT = getattr(settings, 'JSON_LD_DEFAULT_CONTEXT', 'https://schema.org')
+DEFAULT_TYPE = getattr(settings,    'JSON_LD_DEFAULT_TYPE', 'Thing')
+GENERATE_URL = getattr(settings,    'JSON_LD_GENERATE_URL', True)

--- a/django_json_ld/views.py
+++ b/django_json_ld/views.py
@@ -1,0 +1,44 @@
+from django.views.generic.detail import DetailView
+
+from . import settings
+
+
+INITIAL_STRUCTURED_DATA = {}
+if settings.DEFAULT_CONTEXT:
+    INITIAL_STRUCTURED_DATA["@context"] = settings.DEFAULT_CONTEXT
+if settings.DEFAULT_TYPE:
+    INITIAL_STRUCTURED_DATA["@type"] = settings.DEFAULT_TYPE
+
+
+class JsonLdContextMixin(object):
+    """
+    CBV mixin which sets sets structured data within the context
+    """
+    structured_data = INITIAL_STRUCTURED_DATA
+
+    def get_structured_data(self, instance=None):
+        if settings.GENERATE_URL:
+            self.structured_data["url"] = self.request.build_absolute_uri(self.request.get_full_path())
+
+        if instance:
+            model_structured_data = getattr(instance, settings.MODEL_ATTRIBUTE)
+            self.structured_data.update(model_structured_data)
+
+        return self.structured_data.copy()
+
+    def get_context_data(self, **kwargs):
+        context = super(JsonLdContextMixin, self).get_context_data(**kwargs)
+        try:
+            obj = kwargs.get('object', self.object)
+        except AttributeError:
+            obj = None
+        context[settings.CONTEXT_ATTRIBUTE] = self.get_structured_data(instance=obj)
+        return context
+
+
+class JsonLdDetailView(JsonLdContextMixin, DetailView):
+    """
+    Render a "detail" view with structured data taken from of an object.
+
+    By default implement property `sd` in the model to return structured data in a dict.
+    """


### PR DESCRIPTION
Hello @hiimdoublej 

This PR adds a CBV mixin and a Detail View making it easier to generate structured data from models in CBV Detail views. Using the default settings all it takes is to add an attribute to the model that returns dict with structured data.

Let me know if you want me to make any changes.

Cheers