### PR TITLE
 Add support for CBV generic.View 

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This is a django template tag to help developers render [structured data](https://developers.google.com/search/docs/guides/intro-structured-data) tags inside their django templates.
 
+Furthermore a collection of views and mixins are included:
+ * `JsonLdContextMixin`, `JsonLdView`
+ * `JsonLdSingleObjectMixin`, `JsonLdDetailView`
+
 ## Installation
 Install using `pip`:
 ```
@@ -69,6 +73,46 @@ Would render into:
 
 ### Class-Based View example
 
+#### Simple View
+
+views.py
+```python
+from django_json_ld.views import JsonLdContextMixin
+
+class HomeView(JsonLdContextMixin, generic.ListView):
+    structured_data = {
+        "@type": "Organization",
+        "name": "The Company",
+    }
+    
+    def get_structured_data(self):
+        structured_data = super(HomeView, self).get_structured_data()
+        structured_data["event"] = get_next_event()
+        return structured_data
+```
+
+By using  `{% render_json_ld sd %}`, as explained in the previous example, would render into something like:
+
+```json
+{
+    "@context":"https://schema.org",    
+    "@type":"Organization",
+    "name":"The Company",
+    "url":"http://example.org/",
+    "event": {
+        "@type": "Event",
+        "about": ["Hodler","Monet","Munch"],
+        "name": "Peindre l'impossible",
+        "startDate": "2016-09-15",
+        "endDate": "2017-01-22"
+    }
+}
+```
+
+In the above example `JsonLdContextMixin` adds `sd` to `HomeView`'s context.
+
+#### Detail View
+
 views.py
 ```python
 from django_json_ld.views import JsonLdDetailView
@@ -92,7 +136,7 @@ class Product(models.Model):
         }
 ```
 
-By using  `{% render_json_ld sd %}`, as explained in the previous example, would render into something like:
+By using  `{% render_json_ld sd %}`, as explained previously, would render into something like:
 
 ```json
 {

--- a/django_json_ld/views.py
+++ b/django_json_ld/views.py
@@ -1,4 +1,4 @@
-from django.views.generic.detail import DetailView
+from django.views import generic
 
 from . import settings
 
@@ -16,29 +16,40 @@ class JsonLdContextMixin(object):
     """
     structured_data = INITIAL_STRUCTURED_DATA
 
-    def get_structured_data(self, instance=None):
-        if settings.GENERATE_URL:
+    def get_structured_data(self):
+        if settings.GENERATE_URL and "url" not in self.structured_data:
             self.structured_data["url"] = self.request.build_absolute_uri(self.request.get_full_path())
-
-        if instance:
-            model_structured_data = getattr(instance, settings.MODEL_ATTRIBUTE)
-            self.structured_data.update(model_structured_data)
-
         return self.structured_data.copy()
 
     def get_context_data(self, **kwargs):
         context = super(JsonLdContextMixin, self).get_context_data(**kwargs)
-        try:
-            obj = kwargs.get('object', self.object)
-        except AttributeError:
-            obj = None
-        context[settings.CONTEXT_ATTRIBUTE] = self.get_structured_data(instance=obj)
+        context[settings.CONTEXT_ATTRIBUTE] = self.get_structured_data()
         return context
 
 
-class JsonLdDetailView(JsonLdContextMixin, DetailView):
+class JsonLdView(JsonLdContextMixin, generic.View):
     """
-    Render a "detail" view with structured data taken from of an object.
+    Render a view with structured data.
+
+    Set `structured_data` with structured data constant fields.
+    Override `get_structured_data` for any dynamic fields.
+    """
+
+
+class JsonLdSingleObjectMixin(JsonLdContextMixin):
+    """
+    CBV mixin which sets sets structured data within the context for a single object
+    """
+    def get_structured_data(self):
+        super(JsonLdSingleObjectMixin, self).get_structured_data()
+        model_structured_data = getattr(self.object, settings.MODEL_ATTRIBUTE)
+        self.structured_data.update(model_structured_data)
+        return self.structured_data.copy()
+
+
+class JsonLdDetailView(JsonLdSingleObjectMixin, generic.DetailView):
+    """
+    Render a "detail" view with structured data taken from object.
 
     By default implement property `sd` in the model to return structured data in a dict.
     """

--- a/django_json_ld/views.py
+++ b/django_json_ld/views.py
@@ -3,18 +3,24 @@ from django.views import generic
 from . import settings
 
 
-INITIAL_STRUCTURED_DATA = {}
+DEFAULT_STRUCTURED_DATA = {}
 if settings.DEFAULT_CONTEXT:
-    INITIAL_STRUCTURED_DATA["@context"] = settings.DEFAULT_CONTEXT
+    DEFAULT_STRUCTURED_DATA["@context"] = settings.DEFAULT_CONTEXT
 if settings.DEFAULT_TYPE:
-    INITIAL_STRUCTURED_DATA["@type"] = settings.DEFAULT_TYPE
+    DEFAULT_STRUCTURED_DATA["@type"] = settings.DEFAULT_TYPE
 
 
 class JsonLdContextMixin(object):
     """
-    CBV mixin which sets sets structured data within the context
+    CBV mixin which sets structured data within the view's context
     """
-    structured_data = INITIAL_STRUCTURED_DATA
+    structured_data = {}
+
+    def __init__(self):
+        super(JsonLdContextMixin, self).__init__()
+        instance_structured_data = DEFAULT_STRUCTURED_DATA.copy()
+        instance_structured_data.update(self.structured_data)
+        self.structured_data = instance_structured_data
 
     def get_structured_data(self):
         if settings.GENERATE_URL and "url" not in self.structured_data:
@@ -38,7 +44,7 @@ class JsonLdView(JsonLdContextMixin, generic.View):
 
 class JsonLdSingleObjectMixin(JsonLdContextMixin):
     """
-    CBV mixin which sets sets structured data within the context for a single object
+    CBV mixin which sets structured data for a single object within the context
     """
     def get_structured_data(self):
         super(JsonLdSingleObjectMixin, self).get_structured_data()


### PR DESCRIPTION
Hi @hiimdoublej,

This PR adds support for `generic.View`. Now it won't try to read `self.object` unless it's a DetailView.

Made the class attribute `structured_data` more flexible by only setting its defaults values in `JsonLdContextMixin.__init__()`. When using `JsonLdContextMixin`, this allows the users to set `structured_data` with any values they want and defaults such as `@context` are still applied.

Let me know if you have any questions or want me to change anything.

Cheers