### PR TITLE
Add support for lazy translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ class HomeView(JsonLdContextMixin, generic.ListView):
     structured_data = {
         "@type": "Organization",
         "name": "The Company",
+        "description": _("A great company."),
     }
     
     def get_structured_data(self):
@@ -98,6 +99,7 @@ By using  `{% render_json_ld sd %}`, as explained in the previous example, would
     "@context":"https://schema.org",    
     "@type":"Organization",
     "name":"The Company",
+    "description":"Uma grande empresa.",
     "url":"http://example.org/",
     "event": {
         "@type": "Event",
@@ -109,7 +111,8 @@ By using  `{% render_json_ld sd %}`, as explained in the previous example, would
 }
 ```
 
-In the above example `JsonLdContextMixin` adds `sd` to `HomeView`'s context.
+In the above example `JsonLdContextMixin` adds `sd` to `HomeView`'s context. 
+`django_json_ld` supports lazy translations, hence `"description"` showing the translated version of its original value.
 
 #### Detail View
 

--- a/django_json_ld/templatetags/json_ld.py
+++ b/django_json_ld/templatetags/json_ld.py
@@ -3,11 +3,13 @@ import json
 from django import template
 from django.utils.safestring import mark_safe
 
+from ..util import LazyEncoder
+
 register = template.Library()
 
 
 @register.simple_tag
 def render_json_ld(structured_data):
-    dumped = json.dumps(structured_data, ensure_ascii=False)
+    dumped = json.dumps(structured_data, ensure_ascii=False, cls=LazyEncoder)
     text = "<script type=application/ld+json>{dumped}</script>".format(dumped=dumped)
     return mark_safe(text)

--- a/django_json_ld/util.py
+++ b/django_json_ld/util.py
@@ -1,0 +1,15 @@
+from django.utils.functional import Promise
+from django.utils.encoding import force_text
+from django.core.serializers.json import DjangoJSONEncoder
+
+
+class LazyEncoder(DjangoJSONEncoder):
+    """
+    Force lazy strings to text
+
+    see: https://stackoverflow.com/a/31746279/4249576
+    """
+    def default(self, obj):
+        if isinstance(obj, Promise):
+            return force_text(obj)
+        return super(LazyEncoder, self).default(obj)


### PR DESCRIPTION
Hey @hiimdoublej,

The project I'm working on is multilingual and uses gettext lazy translations. This PR make the json dump support lazy strings.

See https://stackoverflow.com/a/31746279/4249576 for more details on the fix I used.

Cheers