### PR TITLE
empty_input_render suggestions

### DIFF
--- a/django_json_ld/templatetags/json_ld.py
+++ b/django_json_ld/templatetags/json_ld.py
@@ -4,7 +4,7 @@ from django import template
 from django.utils.safestring import mark_safe
 from django.template import TemplateSyntaxError
 
-from ..util import LazyEncoder, validate_sd
+from ..util import LazyEncoder, validate_sd, build_absolute_uri
 from .. import settings
 
 register = template.Library()
@@ -28,9 +28,9 @@ def render_json_ld(context, structured_data):
             return ''
         elif empty_input_choice == 'generate_thing':
             structured_data = {
-                "@context": "https://schema.org",
-                "@type": "Thing",
-                "url": context['request'].build_absolute_uri(),
+                "@context": settings.DEFAULT_CONTEXT,
+                "@type": settings.DEFAULT_TYPE,
+                "url": build_absolute_uri(context['request']),
             }
     dumped = json.dumps(structured_data, ensure_ascii=False, cls=LazyEncoder)
     text = "<script type=application/ld+json>{dumped}</script>".format(

--- a/django_json_ld/util.py
+++ b/django_json_ld/util.py
@@ -4,10 +4,15 @@ from django.core.serializers.json import DjangoJSONEncoder
 
 
 def validate_sd(sd):
-    if type(sd) != dict:
+    if sd and type(sd) != dict:
         err = 'Invalid type for provided structured data, expected "dict", got {}'.format(type(sd))
         return False, err
     return True, None
+
+
+def build_absolute_uri(request):
+    return request.build_absolute_uri()
+
 
 class LazyEncoder(DjangoJSONEncoder):
     """

--- a/django_json_ld/views.py
+++ b/django_json_ld/views.py
@@ -1,6 +1,7 @@
 from django.views import generic
 
 from . import settings
+from .util import build_absolute_uri
 
 
 DEFAULT_STRUCTURED_DATA = {}
@@ -24,7 +25,7 @@ class JsonLdContextMixin(object):
 
     def get_structured_data(self):
         if settings.GENERATE_URL and "url" not in self.structured_data:
-            self.structured_data["url"] = self.request.build_absolute_uri(self.request.get_full_path())
+            self.structured_data["url"] = build_absolute_uri(self.request)
         return self.structured_data.copy()
 
     def get_context_data(self, **kwargs):


### PR DESCRIPTION
Hey @hiimdoublej 

### validate_sd: allow any empty structure
As per my previous comment, allow a context without `sd` to pass this validation. If `'strict'` mode is on it will still raise an error later on.

### generate_thing: use default @context and @type
I think the new created `Thing` should be consistent with CBV default behavour.

### use our own build_absolute_uri() function
Use a common `build_absolute_uri()` in case one day we want to change it. This way we ensure behaviour will be consistent across the package in the future.

Let me know if you have questions!

Cheers