### PR TITLE
render_json_ld: sort keys so results are predicable and consistent

### DIFF
--- a/django_json_ld/templatetags/json_ld.py
+++ b/django_json_ld/templatetags/json_ld.py
@@ -32,7 +32,7 @@ def render_json_ld(context, structured_data):
                 "@type": settings.DEFAULT_TYPE,
                 "url": build_absolute_uri(context['request']),
             }
-    dumped = json.dumps(structured_data, ensure_ascii=False, cls=LazyEncoder)
+    dumped = json.dumps(structured_data, ensure_ascii=False, cls=LazyEncoder, sort_keys=True)
     text = "<script type=application/ld+json>{dumped}</script>".format(
         dumped=dumped)
     return mark_safe(text)


### PR DESCRIPTION
@hiimdoublej,

This PR sorts the output of json.dumps by key so we always get the same output for the same data. The performance penalty should be irrelevant.

Cheers