### PR TITLE
fix(utils): Update force_text to force_str

### DIFF
--- a/django_json_ld/util.py
+++ b/django_json_ld/util.py
@@ -1,7 +1,7 @@
 import collections
 
 from django.utils.functional import Promise
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.core.serializers.json import DjangoJSONEncoder
 
 
@@ -24,5 +24,5 @@ class LazyEncoder(DjangoJSONEncoder):
     """
     def default(self, obj):
         if isinstance(obj, Promise):
-            return force_text(obj)
+            return force_str(obj)
         return super(LazyEncoder, self).default(obj)


### PR DESCRIPTION
force_text() is deprecated in favor of force_str().
This commit makes the library Django 4 compat.

Closes #24 