### PR TITLE
Add support for multiple types and optional kwargs on Views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ For more general information, view the [readme](README.md).
 ## [0.0.6] -- 2023-03-06
 
 - feat(utils): Add support for multiple types (#32) by @denisroldan
+- feat(views): Support optional kwargs on views (#32) by @denisroldan
 
 ## [0.0.5] -- 2022-02-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 For more general information, view the [readme](README.md).
 
+## [0.0.6] -- 2023-03-06
+
+- feat(utils): Add support for multiple types (#32) by @denisroldan
+
 ## [0.0.5] -- 2022-02-01
 
 - fix(utils): Update force_text to force_str (#25) by @denisroldan

--- a/django_json_ld/__init__.py
+++ b/django_json_ld/__init__.py
@@ -1,2 +1,2 @@
 __author__ = 'Johnny Chang'
-__version__ = '0.0.5'
+__version__ = '0.0.6'

--- a/django_json_ld/util.py
+++ b/django_json_ld/util.py
@@ -6,8 +6,8 @@ from django.core.serializers.json import DjangoJSONEncoder
 
 
 def validate_sd(sd):
-    if sd and not isinstance(sd, Mapping):
-        err = 'Invalid type for provided structured data, expected "dict", got {}'.format(type(sd))
+    if sd and (type(sd) not in [Mapping, list]):
+        err = 'Invalid type for provided structured data, expected "dict" or "list", got {}'.format(type(sd))
         return False, err
     return True, None
 

--- a/django_json_ld/util.py
+++ b/django_json_ld/util.py
@@ -6,7 +6,7 @@ from django.core.serializers.json import DjangoJSONEncoder
 
 
 def validate_sd(sd):
-    if sd and (type(sd) not in [Mapping, list]):
+    if sd and (type(sd) not in [Mapping, dict, list]):
         err = 'Invalid type for provided structured data, expected "dict" or "list", got {}'.format(type(sd))
         return False, err
     return True, None

--- a/django_json_ld/views.py
+++ b/django_json_ld/views.py
@@ -82,7 +82,7 @@ class JsonLdMultipleObjectMixin(JsonLdContextMixin):
     """
     CBV mixin which sets structured data for a multiple objects within the context
     """
-    def __init__(self):
+    def __init__(self, **kwargs):
         if not self.structured_data:
             self.structured_data = {}
         if "@graph" not in self.structured_data:

--- a/django_json_ld/views.py
+++ b/django_json_ld/views.py
@@ -17,7 +17,7 @@ class JsonLdContextMixin(object):
     """
     structured_data = None
 
-    def __init__(self):
+    def __init__(self, **kwargs):
         super(JsonLdContextMixin, self).__init__()
 
         if not self.structured_data:


### PR DESCRIPTION
This PR addresses two problems:
- Updates the `validate_sd` function to also allow a list of elements and not only single dictionaries.

Even if it's not purely a standard application of the schema.org specification, Google allows you to set a list of types on the same page. This is useful for pages where you have a Local Business and it's part of a directory, so you want to also add breadcrumbs on it. Another example is a recipe, which could be placed under "Oriental" > "Spicy" > "Curries". The recipe is a valid JSON schema and also breadcrumbs to improve search results appearance.

You can test it [here](https://search.google.com/test/rich-results/result?id=A9uWidDsYvnYzTTakRFm3A) or, in case the link doesn't work, [here](https://search.google.com/test/rich-results/result) with the following data:

```
[{"@context": "https://schema.org/", "@id": "/madrid/madrid/this-is-a-test/", "@type": "LocalBusiness", "address": {"@type": "PostalAddress", "addressCountry": "ES", "addressLocality": "Madrid", "addressRegion": "Madrid", "postalCode": 28000, "streetAddress": "A street, 28043 Madrid, Spain"}, "aggregateRating": {"@type": "AggregateRating", "ratingValue": 3.7, "reviewCount": 42}, "description": "This is a long description", "latitude": "40.4123123", "longitude": "-3.123123", "name": "Test name", "priceRange": "€€€", "telephone": "91000000", "url": "/this/is/a/test/"}, {"@context": "https://schema.org", "@type": "BreadcrumbList", "itemListElement": [{"@type": "ListItem", "item": "https://test.com/madrid/", "name": "Madrid", "position": 1}, {"@type": "ListItem", "item": "https://test.com/madrid/madrid/", "name": "City of Madrid", "position": 2}]}]
```

- Adds missing `**kwargs` on `JsonLdContextMixin` and `JsonLdMultipleObjectMixin`.

If you create a View with an optional param, you can overwrite that param directly from the `urls.py`. For example:

```py
class MyGreatListView(ListView):
    scoped = False
```

And then on the urls.py you can do:

```py
    path(
        "list/",
        MyGreatListView.as_view(),
        name='unscoped-list',
    ),
    path(
        "scoped-list/",
        MyGreatListView.as_view(scoped=True),
        name='scoped-list',
    ),
```

The problem is that you can have multiple mixins on your view and inherit from `JsonLdContextMixin` or `JsonLdMultipleObjectMixin`. In that case, without this fix, the view breaks as[ the signature is different on Django generic views](https://github.com/django/django/blob/main/django/views/generic/base.py#L53) than on json-ld. 