### PR TITLE
feat(views): Support optional kwargs on views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 For more general information, view the [readme](README.md).
 
+## [0.0.6] -- 2023-03-09
+
+- feat(views): Support optional kwargs on views (#33) by @denisroldan
+
 ## [0.0.5] -- 2022-02-01
 
 - fix(utils): Update force_text to force_str (#25) by @denisroldan

--- a/django_json_ld/__init__.py
+++ b/django_json_ld/__init__.py
@@ -1,2 +1,2 @@
 __author__ = 'Johnny Chang'
-__version__ = '0.0.5'
+__version__ = '0.0.6'

--- a/django_json_ld/views.py
+++ b/django_json_ld/views.py
@@ -17,7 +17,7 @@ class JsonLdContextMixin(object):
     """
     structured_data = None
 
-    def __init__(self):
+    def __init__(self, **kwargs):
         super(JsonLdContextMixin, self).__init__()
 
         if not self.structured_data:
@@ -82,7 +82,7 @@ class JsonLdMultipleObjectMixin(JsonLdContextMixin):
     """
     CBV mixin which sets structured data for a multiple objects within the context
     """
-    def __init__(self):
+    def __init__(self, **kwargs):
         if not self.structured_data:
             self.structured_data = {}
         if "@graph" not in self.structured_data:


### PR DESCRIPTION
## Add missing **kwargs on JsonLdContextMixin and JsonLdMultipleObjectMixin.

If you create a View with an optional param, you can overwrite that param directly from the urls.py. For example:

```py
class MyGreatListView(ListView):
    scoped = False
```

And then on the urls.py you can do:

```py
    path(
        "list/",
        MyGreatListView.as_view(),
        name='unscoped-list',
    ),
    path(
        "scoped-list/",
        MyGreatListView.as_view(scoped=True),
        name='scoped-list',
    ),
```

The problem is that you can have multiple mixins on your view and inherit from JsonLdContextMixin or JsonLdMultipleObjectMixin. In that case, without this fix, the view breaks as[ the signature is different on Django generic views](https://github.com/django/django/blob/main/django/views/generic/base.py#L53) than on json-ld.

This PR also does a version bump ;)